### PR TITLE
updated dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,5 @@ matrix:
   exclude:
     - env: PROJECT=play-json
       jdk: oraclejdk7
+    - env: PROJECT=play-json
+      scala: "2.10.5"

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -4,9 +4,9 @@ import Keys._
 object Dependencies {
   // Versions
   object V {
-    val jodaMoney   = "0.10.0"
-    val jodaConvert = "1.2"
-    val play        = "2.4.2"
+    val jodaMoney   = "0.11"
+    val jodaConvert = "1.8"
+    val play        = "2.5.9"
     val scalacheck  = "1.11.6"
   }
 


### PR DESCRIPTION
- play-json -> 2.5.9
- joda-money -> 0.11
- joda-convert -> 1.8

Especiall play-json is important as when using the curreny play 2.5.9, you'll get a RuntimeException when trying to use the provided Json Reads:

```
java.lang.NoSuchMethodError: Fatal execution error, caused by play.api.libs.functional.syntax.package$.functionalCanBuildApplicative(Lplay/api/libs/functional/Applicative;)Lplay/api/libs/functional/FunctionalCanBuild;
java.lang.NoSuchMethodError: play.api.libs.functional.syntax.package$.functionalCanBuildApplicative(Lplay/api/libs/functional/Applicative;)Lplay/api/libs/functional/FunctionalCanBuild;
	at com.github.nscala_money.money.json.play.JodaMoneyReads$$anon$2.<init>(JodaMoneyReads.scala:85)
	at com.github.nscala_money.money.json.play.JodaMoneyReads$class.MoneyReads(JodaMoneyReads.scala:84)
	at com.github.nscala_money.money.json.play.JodaMoneyReads$.MoneyReads(JodaMoneyReads.scala:24)
	at com.github.nscala_money.money.json.play.JodaMoneyReads$$anon$1.<init>(JodaMoneyReads.scala:76)
	at com.github.nscala_money.money.json.play.JodaMoneyReads$class.DefaultMoneyReads(JodaMoneyReads.scala:75)
	at com.github.nscala_money.money.json.play.JodaMoneyReads$.DefaultMoneyReads(JodaMoneyReads.scala:24)
	at com.github.nscala_money.money.json.play.ReadsImplicits$class.$init$(Implicits.scala:28)
	at com.github.nscala_money.money.json.play.Imports$.<init>(Imports.scala:19)
	at com.github.nscala_money.money.json.play.Imports$.<clinit>(Imports.scala)
	at com.github.nscala_money.money.json.package$.<init>(package.scala:23)
	at com.github.nscala_money.money.json.package$.<clinit>(package.scala)

```

This is due to this commit https://github.com/playframework/playframework/commit/f6935a43a67003b2fd05f29f5f2fd5c6ac4a1002
